### PR TITLE
Add versions on cd

### DIFF
--- a/.github/workflows/linux_x86_64_build.yml
+++ b/.github/workflows/linux_x86_64_build.yml
@@ -28,11 +28,9 @@ jobs:
         run: |
           docker run --rm \
             -e OUTPUT_DIR=/var/mmt/ \
-            -e MMT_VERSION_MAJOR=1 \
-            -e MMT_VERSION_MINOR=2 \
-            -e MMT_VERSION_PATCH=3 \
+            -e MMT_TAG=${{ github.ref }} \
             -v ${{ github.workspace }}:/var/mmt:rw \
-            ghcr.io/raphaelmartin83/memoto_linux_x86_64:8485f18
+            ghcr.io/raphaelmartin83/memoto_linux_x86_64:89e09e8
 
       - name: Persist artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/windows_x86_64_bulid.yml
+++ b/.github/workflows/windows_x86_64_bulid.yml
@@ -28,7 +28,7 @@ jobs:
           docker run --rm \
             -e OUTPUT_DIR=/var/mmt/ \
             -v ${{ github.workspace }}:/var/mmt:rw \
-            ghcr.io/raphaelmartin83/memoto_windows_x86_64:8485f18
+            ghcr.io/raphaelmartin83/memoto_windows_x86_64:bbe68ee
 
       - name: Persist artifacts
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 CMakeLists.txt.user
 *.res
-build*
+./build*

--- a/toolchains/common.sh
+++ b/toolchains/common.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# $1 is the tag
+getVersionFromTag()
+{
+    echo $(printenv MMT_TAG) | awk -F v '{print $2}'
+}
+
+getVersionMajorFromTag()
+{
+    echo $(printenv MMT_TAG) | awk -F v '{print $2}' | awk -F . '{print $1}'
+}
+
+getVersionMinorFromTag()
+{
+    echo $(printenv MMT_TAG) | awk -F v '{print $2}' | awk -F . '{print $2}'
+}
+
+getVersionPatchFromTag()
+{
+    echo $(printenv MMT_TAG) | awk -F v '{print $2}' | awk -F . '{print $3}'
+}

--- a/toolchains/common.sh
+++ b/toolchains/common.sh
@@ -8,15 +8,33 @@ getVersionFromTag()
 
 getVersionMajorFromTag()
 {
-    echo $(printenv MMT_TAG) | awk -F v '{print $2}' | awk -F . '{print $1}'
+    local version_major=$($(printenv MMT_TAG) | awk -F v '{print $2}' | awk -F . '{print $1}')
+    if [[ "" == ${version_major} ]];
+    then
+        echo "0"
+    else
+        echo ${version_major}
+    fi
 }
 
 getVersionMinorFromTag()
 {
-    echo $(printenv MMT_TAG) | awk -F v '{print $2}' | awk -F . '{print $2}'
+    local version_minor=$($(printenv MMT_TAG) | awk -F v '{print $2}' | awk -F . '{print $2}')
+    if [[ "" == ${version_minor} ]];
+    then
+        echo "0"
+    else
+        echo ${version_minor}
+    fi
 }
 
 getVersionPatchFromTag()
 {
-    echo $(printenv MMT_TAG) | awk -F v '{print $2}' | awk -F . '{print $3}'
+    local version_patch=$($(printenv MMT_TAG) | awk -F v '{print $2}' | awk -F . '{print $3}')
+    if [[ "" == ${version_patch} ]];
+    then
+        echo "0"
+    else
+        echo ${version_patch}
+    fi
 }

--- a/toolchains/linux/x86_64/Dockerfile
+++ b/toolchains/linux/x86_64/Dockerfile
@@ -10,46 +10,7 @@ ENV QT_DIR="/usr/lib/qt-dev/" \
 	Qt6_DIR="/usr/lib/qt-dev/" \
 	buildDir="/tmp/buildmmt" \
 	OUTPUT_DIR="/var/mmt" \
-	MMT_VERSION_MAJOR="0" \
-	MMT_VERSION_MINOR="0" \
-	MMT_VERSION_PATCH="0"
+	MMT_TAG="v0.0.0"
 
 
-COPY <<-EOT build.sh
-	set -e
-
-	# Repo is expected to be mapped in /var/mmt
-
-	export PATH=$PATH:$QT_DIR/bin
-
-	cmake -DMEMOTO_VERSION_MAJOR="$(printenv MMT_VERSION_MAJOR)" -DMEMOTO_VERSION_MINOR="$(printenv MMT_VERSION_MINOR)" -DMEMOTO_VERSION_PATCH="$(printenv MMT_VERSION_PATCH)" -DMEMOTO_VERSION_FULL="$(printenv MMT_VERSION_MAJOR).$(printenv MMT_VERSION_MINOR).$(printenv MMT_VERSION_PATCH)" -DCMAKE_BUILD_TYPE=Release -S /var/mmt/MMT/ -B $buildDir
-	cmake --build $buildDir --parallel
-
-	# Extracts the appimage to avoid using fuse (and priviledges associated to it)
-	./linuxdeployqt-continuous-x86_64.AppImage --appimage-extract
-
-	# Creates application tree following linuxdeployqt documentation
-	rm -rf mmt-deploy-root
-	mkdir mmt-deploy-root
-	mkdir mmt-deploy-root/usr
-	mkdir mmt-deploy-root/usr/bin
-	mkdir mmt-deploy-root/usr/lib
-	mkdir mmt-deploy-root/usr/share
-	mkdir mmt-deploy-root/usr/share/applications
-	mkdir -p mmt-deploy-root/usr/share/icons/hicolor/256x256/apps/
-
-	# Copies files
-	cp ${buildDir}/MMT mmt-deploy-root/usr/bin
-	cp /var/mmt/toolchains/linux/MeMoTo.desktop mmt-deploy-root/usr/share/applications/
-	cp /var/mmt/MMT/logo/logo.png mmt-deploy-root/usr/share/icons/hicolor/256x256/apps/MeMoTo.png
-
-	squashfs-root/AppRun mmt-deploy-root/usr/share/applications/MeMoTo.desktop -appimage
-
-	# Publishes file to MeMoTo output dir
-	cp MeMoTo-x86_64.AppImage "$(printenv OUTPUT_DIR)"
-
-	echo ""
-	echo "Output: $(printenv OUTPUT_DIR)/MeMoTo-x86_64.AppImage"
-EOT
-
-ENTRYPOINT ["/bin/bash", "build.sh"]
+ENTRYPOINT ["/bin/bash", "/var/mmt/toolchains/linux/x86_64/build.sh"]

--- a/toolchains/linux/x86_64/build.sh
+++ b/toolchains/linux/x86_64/build.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -e
+
+source /var/mmt/toolchains/common.sh
+
+# Extract version from tag
+MMT_VERSION_FULL=$(getVersionFromTag $MMT_TAG)
+MMT_VERSION_MAJOR=$(getVersionMajorFromTag $MMT_TAG)
+MMT_VERSION_MINOR=$(getVersionMinorFromTag $MMT_TAG)
+MMT_VERSION_PATCH=$(getVersionPatchFromTag $MMT_TAG)
+
+# Repo is expected to be mapped in /var/mmt
+
+export PATH=$PATH:$QT_DIR/bin
+
+cmake -DMEMOTO_VERSION_MAJOR="${MMT_VERSION_MAJOR}" -DMEMOTO_VERSION_MINOR="${MMT_VERSION_MINOR}" -DMEMOTO_VERSION_PATCH="${MMT_VERSION_PATCH}" -DMEMOTO_VERSION_FULL="${MMT_VERSION_FULL}" -DCMAKE_BUILD_TYPE=Release -S /var/mmt/MMT/ -B $buildDir
+cmake --build $buildDir --parallel
+
+# Extracts the appimage to avoid using fuse (and priviledges associated to it)
+./linuxdeployqt-continuous-x86_64.AppImage --appimage-extract
+
+# Creates application tree following linuxdeployqt documentation
+rm -rf mmt-deploy-root
+mkdir mmt-deploy-root
+mkdir mmt-deploy-root/usr
+mkdir mmt-deploy-root/usr/bin
+mkdir mmt-deploy-root/usr/lib
+mkdir mmt-deploy-root/usr/share
+mkdir mmt-deploy-root/usr/share/applications
+mkdir -p mmt-deploy-root/usr/share/icons/hicolor/256x256/apps/
+
+# Copies files
+cp ${buildDir}/MMT mmt-deploy-root/usr/bin
+cp /var/mmt/toolchains/linux/MeMoTo.desktop mmt-deploy-root/usr/share/applications/
+cp /var/mmt/MMT/logo/logo.png mmt-deploy-root/usr/share/icons/hicolor/256x256/apps/MeMoTo.png
+
+squashfs-root/AppRun mmt-deploy-root/usr/share/applications/MeMoTo.desktop -appimage
+
+# Publishes file to MeMoTo output dir
+cp MeMoTo-x86_64.AppImage "$(printenv OUTPUT_DIR)"
+
+echo ""
+echo "Output: $(printenv OUTPUT_DIR)/MeMoTo-x86_64.AppImage"
+

--- a/toolchains/linux/x86_64/build.sh
+++ b/toolchains/linux/x86_64/build.sh
@@ -14,7 +14,14 @@ MMT_VERSION_PATCH=$(getVersionPatchFromTag $MMT_TAG)
 
 export PATH=$PATH:$QT_DIR/bin
 
-cmake -DMEMOTO_VERSION_MAJOR="${MMT_VERSION_MAJOR}" -DMEMOTO_VERSION_MINOR="${MMT_VERSION_MINOR}" -DMEMOTO_VERSION_PATCH="${MMT_VERSION_PATCH}" -DMEMOTO_VERSION_FULL="${MMT_VERSION_FULL}" -DCMAKE_BUILD_TYPE=Release -S /var/mmt/MMT/ -B $buildDir
+cmake \
+  -DMEMOTO_VERSION_MAJOR="${MMT_VERSION_MAJOR}" \
+  -DMEMOTO_VERSION_MINOR="${MMT_VERSION_MINOR}" \
+  -DMEMOTO_VERSION_PATCH="${MMT_VERSION_PATCH}" \
+  -DMEMOTO_VERSION_FULL="${MMT_VERSION_FULL}" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -S /var/mmt/MMT/ \
+  -B $buildDir
 cmake --build $buildDir --parallel
 
 # Extracts the appimage to avoid using fuse (and priviledges associated to it)

--- a/toolchains/windows/x86_64/Dockerfile
+++ b/toolchains/windows/x86_64/Dockerfile
@@ -62,19 +62,4 @@ RUN cd /var \
 	&& cd mxe \
 	&& make qt6 MXE_TARGETS="x86_64-w64-mingw32.static"
 
-ENV MMT_VERSION_MAJOR="0" \
-	MMT_VERSION_MINOR="0" \
-	MMT_VERSION_PATCH="0"
-
-COPY <<-EOT build.sh
-	set -e
-
-	# Repo is expected to be mapped in /var/mmt
-	export PATH=${MXE_USR_DIR}/bin:$PATH
-
-	mkdir -p $(printenv OUTPUT_DIR)/build_winx86_64
-	${MXE_USR_DIR}/bin/x86_64-w64-mingw32.static-cmake -DMEMOTO_VERSION_MAJOR="$(printenv MMT_VERSION_MAJOR)" -DMEMOTO_VERSION_MINOR="$(printenv MMT_VERSION_MINOR)" -DMEMOTO_VERSION_PATCH="$(printenv MMT_VERSION_PATCH)" -DMEMOTO_VERSION_FULL="$(printenv MMT_VERSION_MAJOR).$(printenv MMT_VERSION_MINOR).$(printenv MMT_VERSION_PATCH)" -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${MXE_USR_DIR}/x86_64-w64-mingw32.static -S /var/mmt/MMT/ -B $(printenv OUTPUT_DIR)/build_winx86_64
-	${MXE_USR_DIR}/bin/x86_64-w64-mingw32.static-cmake --build $(printenv OUTPUT_DIR)/build_winx86_64 --parallel
-EOT
-
-ENTRYPOINT ["/bin/bash", "build.sh"]
+ENTRYPOINT ["/bin/bash", "/var/mmt/toolchains/windows/x86_64/build.sh"]

--- a/toolchains/windows/x86_64/build.sh
+++ b/toolchains/windows/x86_64/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+source /var/mmt/toolchains/common.sh
+
+# Extract version from tag
+MMT_VERSION_FULL=$(getVersionFromTag $MMT_TAG)
+MMT_VERSION_MAJOR=$(getVersionMajorFromTag $MMT_TAG)
+MMT_VERSION_MINOR=$(getVersionMinorFromTag $MMT_TAG)
+MMT_VERSION_PATCH=$(getVersionPatchFromTag $MMT_TAG)
+
+# Repo is expected to be mapped in /var/mmt
+export PATH=${MXE_USR_DIR}/bin:$PATH
+
+mkdir -p $(printenv OUTPUT_DIR)/build_winx86_64
+${MXE_USR_DIR}/bin/x86_64-w64-mingw32.static-cmake \
+  -DMEMOTO_VERSION_MAJOR="${MMT_VERSION_MAJOR}" \
+  -DMEMOTO_VERSION_MINOR="${MMT_VERSION_MINOR}" \
+  -DMEMOTO_VERSION_PATCH="${MMT_VERSION_PATCH}" \
+  -DMEMOTO_VERSION_FULL="${MMT_VERSION_FULL}" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_PREFIX_PATH=${MXE_USR_DIR}/x86_64-w64-mingw32.static \
+  -S /var/mmt/MMT/ \
+  -B $(printenv OUTPUT_DIR)/build_winx86_64
+
+${MXE_USR_DIR}/bin/x86_64-w64-mingw32.static-cmake --build $(printenv OUTPUT_DIR)/build_winx86_64 --parallel


### PR DESCRIPTION
Because I forgot finishing the work last time, every MeMoTo delivery had version 1.2.3.
This PR finishes the work and also removes the build scripts from the docker containers so it's easier to change next time.